### PR TITLE
Bump google-api-services-oauth2

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile 'org.slf4j:slf4j-simple:1.7.25'
     compile 'com.google.code.gson:gson:2.8.1'
     compile 'org.mongodb:mongodb-driver:3.4.2'
-    compile 'com.google.apis:google-api-services-oauth2:v1-rev139-1.23.0'
+    compile 'com.google.apis:google-api-services-oauth2:v2-rev20180628-1.28.0'
     compile 'org.json:json:20180130'
 
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Bumps google-api-services-oauth2 from v1-rev139-1.23.0 to v2-rev20180628-1.28.0.

Signed-off-by: dependabot[bot] <support@dependabot.com>