### PR TITLE
Change oracle -> open jdk8 to test Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 jdk:
-    - oraclejdk8
+    - openjdk8
 
 sudo: required
 


### PR DESCRIPTION
Travis has been failing for awhile for some people due to upgrades in
their required JDKs. Olafurgp's suggestion is being attempted.