### PR TITLE
Remove "-sm=false" from runClientTestWithCoverage

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -31,7 +31,7 @@ task runClientTestsAndWatch(type: NpmTask) {
 task runClientTestWithCoverage(type: Exec, dependsOn: yarn_install) {
     group = 'application'
     executable "ng"
-    args = ["test", "-sm=false", "--watch=false", "--code-coverage"]
+    args = ["test", "--watch=false", "--code-coverage"]
 }
 
 task runE2ETest(type:Exec){


### PR DESCRIPTION
Chuck said that the coverage run was failing due to that option and that
was correct.