### PR TITLE
Fix shirt size mat-select

### DIFF
--- a/client/src/app/accountInfo/accountInfo.component.html
+++ b/client/src/app/accountInfo/accountInfo.component.html
@@ -11,12 +11,14 @@
                     <h3 *ngIf="user && !isEditing">Shirt Size: {{getShirtSize()}}</h3>
                     <h3 *ngIf="user && isEditing">Shirt Size: </h3>
                     <div class="edit-form" *ngIf="isEditing">
-                        <mat-select [(value)]="user.ShirtSize"
-                                    (selectionChange)="saveUserShirtSize($event.source.value)">
-                            <mat-option *ngFor="let size of shirtSizes" [value]="size.value">
-                                {{size.viewValue}}
-                            </mat-option>
-                        </mat-select>
+                        <mat-form-field>
+                            <mat-select [(ngModel)]="user.ShirtSize">
+                                <mat-option *ngFor="let size of shirtSizes" [value]="size.value"
+                                            (click)="saveUserShirtSize(user.ShirtSize)">
+                                    {{size.viewValue}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
                     </div>
                     <mat-icon class="edit-icon" *ngIf="!isEditing" (click)="changeEditState()">edit</mat-icon>
                 </div>

--- a/client/src/app/accountInfo/accountInfo.component.scss
+++ b/client/src/app/accountInfo/accountInfo.component.scss
@@ -57,6 +57,10 @@
     vertical-align: middle;
 }
 
+.profile-shirt-size > h3 {
+    padding-right: .7em;
+}
+
 .profile-shirt-size {
     margin-top: -4%;
 }
@@ -66,12 +70,8 @@
     cursor: pointer;
 }
 
-.edit-form {
-    margin-bottom: 1em;
-}
-
 mat-form-field {
-    width: 80%;
+    width: 100%;
 }
 
 .sign-out-option {
@@ -86,6 +86,16 @@ mat-form-field {
 
     .profile-pic-wrapper {
         margin: 1.25rem 1.25rem 1.25rem 1rem;
+        width: 35%;
+        max-width: 140px;
+    }
+
+    .profile-details {
+        width: calc(65% - 2.5rem);
+    }
+
+    mat-form-field {
+        width: 70%;
     }
 
     .profile-pic {


### PR DESCRIPTION
The current shirt size is now shown as the initial select value. Selecting the currently selected value saves it. Before, this would keep the mat-select open until a different value was selected.