### PR TITLE
Make .submission-card-container mid-width 300px

### DIFF
--- a/client/src/app/submissionList/submissionList.component.scss
+++ b/client/src/app/submissionList/submissionList.component.scss
@@ -10,7 +10,7 @@
 .submission-card-container > div {
     background-color: white;
     max-width: 800px;
-    min-width: 400px;
+    min-width: 300px; //iPhone 5/SE is 320px wide, screen would get cut off at higher than 320px
     width: 100%;
     border: 1px solid #4b4b4b;
     border-bottom: 0;


### PR DESCRIPTION
Fixes submission cards being cut off on screen sizes smaller than the
old value of 400. Perhaps the minimum could stand to be 310px min
baseline, or adding media queries for some phones in the higher 300ish
px range, like iPhone 6/7/8 at 375px width to have higher min-widths.

#99